### PR TITLE
Heroku Deployment + Django/bower integration

### DIFF
--- a/.buildpacks
+++ b/.buildpacks
@@ -1,0 +1,2 @@
+https://github.com/heroku/heroku-buildpack-nodejs.git
+https://github.com/heroku/heroku-buildpack-python.git

--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: gunicorn settings.wsgi_settings --log-file -

--- a/manage.py
+++ b/manage.py
@@ -3,7 +3,7 @@ import os
 import sys
 
 if __name__ == "__main__":
-    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "settings.default_settings")
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "settings")
 
     from django.core.management import execute_from_command_line
 

--- a/package.json
+++ b/package.json
@@ -1,0 +1,9 @@
+{
+  "private": true,
+  "dependencies": {
+    "bower": "*"
+  },
+  "scripts": {
+    "postinstall": "bower install"
+  }
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,18 @@
 # `pip install -r requirements.txt` in a terminal window.  It will read the
 # dependencies from this file, and install them and their dependencies!
 
+# Django is the base web framework used for ORM and serving views
 Django==1.8.3
+
+# dj-database-url parses the local environment variable DATABASE_URL
+# serverside and builds the appropriate config object for it
+dj-database-url==0.3.0
+
+# mysqlclient is the preferred connector for using MySQL with Django
+mysqlclient==1.3.6
+
+# gunicorn is a WSGI server used in production
+gunicorn==19.3.0
+
+# whitenoise is a framework for serving static files in production
+whitenoise==2.0.2

--- a/settings/__init__.py
+++ b/settings/__init__.py
@@ -1,1 +1,6 @@
 __author__ = 'zachmccormick'
+
+from settings.default_settings import *
+
+if os.getenv('IS_PROD', False):
+    from settings.prod_settings import *

--- a/settings/default_settings.py
+++ b/settings/default_settings.py
@@ -55,6 +55,10 @@ TIME_ZONE = 'UTC'
 USE_TZ = False
 
 
-# Static files (CSS, JavaScript, Images)
-# In production... I don't know what we'll do yet :-)
+# DjangoWhiteNoise requires STATIC_URL and STATIC_ROOT to be set even though we don't really use them.
+# TEMPLATE_DIRS allows us to serve index.html at the root + WHITENOISE_ROOT allows us to serve files
+# from the public directory directly.  Probably not *best* practice, but it works for us.
 STATIC_URL = '/static/'
+STATIC_ROOT = os.path.join(BASE_DIR, 'staticroot')
+TEMPLATE_DIRS = (os.path.join(BASE_DIR, 'public'),)
+WHITENOISE_ROOT = os.path.join(BASE_DIR, 'public')

--- a/settings/prod_settings.py
+++ b/settings/prod_settings.py
@@ -1,0 +1,16 @@
+import os
+import dj_database_url
+
+__author__ = 'zachmccormick'
+
+# Pull database config from Heroku's dyno's environment variables using dj_database_url
+DATABASES = {'default': dj_database_url.config()}
+
+# For now, allow from all hosts
+ALLOWED_HOSTS = ['*']
+
+# Actual secret key should be pulled from Heroku
+SECRET_KEY = os.getenv('SECRET_KEY', None)
+
+# Why not GZIP and client-cache files?
+STATICFILES_STORAGE = 'whitenoise.django.GzipManifestStaticFilesStorage'

--- a/settings/wsgi_settings.py
+++ b/settings/wsgi_settings.py
@@ -8,7 +8,10 @@ https://docs.djangoproject.com/en/1.7/howto/deployment/wsgi/
 """
 
 import os
-os.environ.setdefault("DJANGO_SETTINGS_MODULE", "settings.default_settings")
+from whitenoise.django import DjangoWhiteNoise
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "settings")
 
 from django.core.wsgi import get_wsgi_application
 application = get_wsgi_application()
+application = DjangoWhiteNoise(application)

--- a/urls.py
+++ b/urls.py
@@ -1,7 +1,8 @@
 from django.conf.urls import patterns, include, url
 from django.contrib import admin
+from django.views.generic import TemplateView
 
 urlpatterns = patterns('',
-    url(r'^$', 'api.views.index'),
+    url(r'^$', TemplateView.as_view(template_name='index.html'), name="home"),
     url(r'^admin/', include(admin.site.urls)),
 )


### PR DESCRIPTION
Enabling Heroku deployment support, with built-in 'bower install' before Django starts serving the files.  Everything should be fairly well commented.  Please raise an issue and tag me if you don't understand how something works or if it isn't intuitive!

Right now, I have a free dyno set up to track the heroku-startup branch on my fork of the project (if I push to it, it redeploys the app).  Sunday we can reconfigure it to pull from master on the main project.