### PR TITLE
Fix sort by projects in brigades list page

### DIFF
--- a/public/js/brigadesCache.js
+++ b/public/js/brigadesCache.js
@@ -16,16 +16,21 @@
   }())
 
   function _getBrigadeProjects(brigades){
+    brigadeDetailsPromises = []
     brigades.forEach(function(brigade){
       //console.log(brigade)
-      $.get(brigade.projects_url, function(projects){
+      var promise = $.get(brigade.projects_url, function(projects){
         brigade["total_projects"] = projects.total.toString();
       })
+      brigadeDetailsPromises.push(promise);
     })
 
-    setTimeout(function(){
+    // Wait until all the $.get requests have resolved before
+    // saving the data back to firebase.
+    $.when.apply(this, brigadeDetailsPromises).done(function(){
+      console.log("Caching Brigade API data to https://cfn-brigadepulse.firebaseio.com/brigadeInfo.json");
       _cacheBrigadesToFirebase(brigadeData);
-    }, 10000)
+    });
   }
 
   function _cacheBrigadesToFirebase(){

--- a/public/js/brigadesCache.js
+++ b/public/js/brigadesCache.js
@@ -20,7 +20,7 @@
     brigades.forEach(function(brigade){
       //console.log(brigade)
       var promise = $.get(brigade.projects_url, function(projects){
-        brigade["total_projects"] = projects.total.toString();
+        brigade["total_projects"] = projects.total;
       })
       brigadeDetailsPromises.push(promise);
     })


### PR DESCRIPTION
The brigades list page was encountering two issues. First, the total_projects field was a String, and sorted on lexical value when passed into the angular orderBy filter. The fix was to remove the "toString" call when the total_projects field was set.

The second issue was the caching mechanism wasn't waiting until all brigade data had been fetched from the BrigadePulse API before caching to firebase, leading to "n/a" default values. Used $.when to defer calling the firebase cache until after all the API calls had resolved.